### PR TITLE
Add Schemas to endpoints and use types in scrapers

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 PORT=9091
 DB_URI="redis://localhost:6379"
+ENABLE_CACHE=true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 // Vlr2 API with HONO and Redis
-import { OpenAPIHono } from '@hono/zod-openapi'
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import { swaggerUI } from '@hono/swagger-ui'
 import { cors } from 'hono/cors'
-import { Routes } from './routes/router'
+import addRoutes from './routes/router'
 import { createClient } from 'redis'
 import 'dotenv/config'
 const DB_URI = process.env.DB_URI || 'redis://redis:6379'
@@ -127,13 +127,12 @@ app.use('/', async (c, next) => {
 })
 
 // Routes
-Routes.forEach((route) => {
 /*Routes.forEach((route) => {
   app.openapi(route.route, (c) => {
     return route.handler(c)
   })
-})
 })*/
+addRoutes(app)
 
 // Swagger UI
 app.get(

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const app = new OpenAPIHono()
 const client = createClient({
   url: DB_URI,
 })
-let CacheEnabled = true
+let CacheEnabled = process.env.CACHE_ENABLED || true
 let ConnectionCount = 0
 // CORS
 app.use(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import addRoutes from './routes/router'
 import { createClient } from 'redis'
 import 'dotenv/config'
 const DB_URI = process.env.DB_URI || 'redis://redis:6379'
-const PORT = process.env.PORT || 9091
+export const PORT = process.env.PORT || 9091
 // Initial Setup
 const app = new OpenAPIHono()
 const client = createClient({
@@ -138,11 +138,6 @@ app.use('/', async (c, next) => {
 })
 
 // Routes
-/*Routes.forEach((route) => {
-  app.openapi(route.route, (c) => {
-    return route.handler(c)
-  })
-})*/
 addRoutes(app)
 
 // Swagger UI

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ app.use('*', async (c, next) => {
     // Cache the response
     const cacheLifespan = () => {
       switch (c.req.path.split('/')[1]) {
-        case 'matches':
+        case 'match':
           return 60 * 60 * 2 // 2 Hours
         default:
           return 60

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Vlr2 API with HONO and Redis
-import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
+import { OpenAPIHono } from '@hono/zod-openapi'
 import { swaggerUI } from '@hono/swagger-ui'
 import { cors } from 'hono/cors'
 import addRoutes from './routes/router'

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,10 +128,12 @@ app.use('/', async (c, next) => {
 
 // Routes
 Routes.forEach((route) => {
+/*Routes.forEach((route) => {
   app.openapi(route.route, (c) => {
     return route.handler(c)
   })
 })
+})*/
 
 // Swagger UI
 app.get(

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,17 @@ app.use('*', async (c, next) => {
     console.log('Not Cached Response')
     // Let the page generate as normal
     await next()
+    // check if the route was not found
+    if (c.res.status === 404) {
+      c.res = c.json(
+        {
+          status: 'error',
+          message: 'Route not found',
+        },
+        404
+      )
+      return
+    }
     // Intercept the JSON
     const data = await c.res.json()
     // Cache the response

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -30,6 +30,8 @@ import {
   EventMatches,
   scoreSchema,
   Score,
+  ErrorSchema,
+  errorSchema,
 } from '../schemas/schemas'
 
 // Types
@@ -334,39 +336,39 @@ function addScoreRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   )
 }
 
-// Working!
-//- Add event specific routes
-const ErrorRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/error/{type}?',
-    tags: ['Event Routes'],
-    request: {
-      params: z.object({
-        type: z.string().optional(),
-      }),
-    },
-    responses: {
-      200: {
-        description: 'Displays a generic error for each type',
-        content: {
-          'application/json': {
-            schema: z.object({
-              status: z.string().openapi({ example: 'error' }),
-              message: z.string().openapi({ example: 'Error: 404' }),
-            }),
+// add Error Route
+function addErrorRoutes(app: OpenAPIHono<Env, {}, '/'>) {
+  //- Add event specific routes
+  // GET /error/{type}
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/error/{type}?',
+      tags: ['Event Routes'],
+      request: {
+        params: z.object({
+          type: z.string().optional(),
+        }),
+      },
+      responses: {
+        200: {
+          description: 'Displays a generic error for each type',
+          content: {
+            'application/json': {
+              schema: errorSchema,
+            },
           },
         },
       },
-    },
-  }),
-  handler: async (c: Context) => {
-    const type = c.req.param('type')
-    return c.json<Object>({
-      status: 'error',
-      message: 'Error: 404',
-    })
-  },
+    }),
+    async (c: Context) => {
+      const type = c.req.param('type')
+      return c.json<ErrorSchema>({
+        status: 'error',
+        message: 'Error: 404',
+      })
+    }
+  )
 }
 
 export default function addRoutes(app: OpenAPIHono<Env, {}, '/'>) {
@@ -375,6 +377,7 @@ export default function addRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   addPlayerRoutes(app)
   addTeamRoutes(app)
   addScoreRoutes(app)
+  addErrorRoutes(app)
 }
 
 /*export const Routes = [

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -9,7 +9,7 @@ import { fetchAllEvents } from '../scrapers/events/all'
 import { fetchOneEvent } from '../scrapers/events/one'
 import { AllMatches, fetchAllMatches } from '../scrapers/matches/all'
 import { Match, fetchOneMatch } from '../scrapers/matches/one'
-import { fetchOnePlayer } from '../scrapers/player/one'
+import { fetchPlayer } from '../scrapers/player/one'
 import { fetchOneTeam } from '../scrapers/team/one'
 import { fetchEventMatches } from '../scrapers/events/matches'
 import { generateScore } from '../scrapers/matches/score'
@@ -20,6 +20,8 @@ import {
   EventSchema,
   IDSchema,
   MatchSchema,
+  Player,
+  playerSchema,
 } from '../schemas/schemas'
 
 // Types
@@ -111,33 +113,35 @@ function addMatchRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   )
 }
 
-// Works Perfectly!
-//- Needs Schema Work
-const PlayerRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/player/{id}',
-    tags: ['Root Routes'],
-    request: {
-      params: IDSchema,
-    },
-    responses: {
-      200: {
-        description: 'Fetches a Player based on their ID from vlr.gg',
-        content: {
-          'application/json': {
-            schema: EventSchema,
+// add All Player Routes
+function addPlayerRoutes(app: OpenAPIHono<Env, {}, '/'>) {
+  // GET /player/{id}
+  // Works Perfectly!
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/player/{id}',
+      tags: ['Root Routes'],
+      request: {
+        params: IDSchema,
+      },
+      description: 'Fetches a Player based on their ID from vlr.gg',
+      responses: {
+        200: {
+          description: 'Fetches a Player based on their ID from vlr.gg',
+          content: {
+            'application/json': {
+              schema: playerSchema,
+            },
           },
         },
       },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Player = await fetchOnePlayer(c.req.param('id')).catch((err) => {
-      throw Error(err)
-    })
-    return c.json<Object>(Player)
-  },
+    }),
+    async (c: Context) => {
+      const Player = await fetchPlayer(c.req.param('id'))
+      return c.json<Player>(Player)
+    }
+  )
 }
 
 // Works Perfectly!
@@ -352,6 +356,7 @@ const ErrorRoute = {
 export default function addRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   addEventsRoute(app)
   addMatchRoutes(app)
+  addPlayerRoutes(app)
 }
 
 /*export const Routes = [

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -89,6 +89,60 @@ function addEventsRoute(app: OpenAPIHono<Env, {}, '/'>) {
       return c.json<Event>(Event)
     }
   )
+
+  // same as above, but with a different route
+  // GET /event/{id}/players
+  app.openapi(
+    {
+      method: 'get',
+      path: '/event/{id}/players',
+      tags: ['Event Routes'],
+      request: {
+        params: IDSchema,
+      },
+      responses: {
+        200: {
+          description: 'Fetches a specific event',
+          content: {
+            'application/json': {
+              schema: eventSchema,
+            },
+          },
+        },
+      },
+    },
+    async (c: Context) => {
+      const Event = await fetchOneEvent(c.req.param('id'))
+      return c.json<Event>(Event)
+    }
+  )
+
+  // same as above, but with a different route
+  // GET /event/{id}/teams
+  app.openapi(
+    {
+      method: 'get',
+      path: '/event/{id}/teams',
+      tags: ['Event Routes'],
+      request: {
+        params: IDSchema,
+      },
+      responses: {
+        200: {
+          description: 'Fetches a specific event',
+          content: {
+            'application/json': {
+              schema: eventSchema,
+            },
+          },
+        },
+      },
+    },
+    async (c: Context) => {
+      const Event = await fetchOneEvent(c.req.param('id'))
+      return c.json<Event>(Event)
+    }
+  )
 }
 
 // add All Routes related to Matches
@@ -154,7 +208,6 @@ function addMatchRoutes(app: OpenAPIHono<Env, {}, '/'>) {
 // add All Player Routes
 function addPlayerRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   // GET /player/{id}
-  // Works Perfectly!
   app.openapi(
     createRoute({
       method: 'get',
@@ -185,7 +238,6 @@ function addPlayerRoutes(app: OpenAPIHono<Env, {}, '/'>) {
 // add All Team Routes
 function addTeamRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   // GET /team/{id}
-  // Works Perfectly!
   app.openapi(
     createRoute({
       method: 'get',
@@ -216,93 +268,6 @@ function addTeamRoutes(app: OpenAPIHono<Env, {}, '/'>) {
       return c.json<Team>(Team)
     }
   )
-}
-
-// Works Perfectly!
-//- Needs Schema Work
-const EventRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/event/{id}',
-    tags: ['Event Routes'],
-    request: {
-      params: IDSchema,
-    },
-    responses: {
-      200: {
-        description: 'Fetches a specific event',
-        content: {
-          'application/json': {
-            schema: shortEventSchema,
-          },
-        },
-      },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Event = await fetchOneEvent(c.req.param('id')).catch((err) => {
-      throw Error(err)
-    })
-    return c.json<Object>(Event)
-  },
-}
-// Untested
-//- Needs Schema Work
-const EventPlayersRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/event/{id}/players',
-    tags: ['Event Routes'],
-    request: {
-      params: IDSchema,
-    },
-    responses: {
-      200: {
-        description: 'Fetches a specific event',
-        content: {
-          'application/json': {
-            schema: shortEventSchema,
-          },
-        },
-      },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Event = await fetchOneEvent(c.req.param('id'))
-    return c.json<Object>({
-      status: 'success',
-      data: Event,
-    })
-  },
-}
-// Untested
-//- Needs Schema Work
-const EventTeamsRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/event/{id}/teams',
-    tags: ['Event Routes'],
-    request: {
-      params: IDSchema,
-    },
-    responses: {
-      200: {
-        description: 'Fetches a specific event',
-        content: {
-          'application/json': {
-            schema: shortEventSchema,
-          },
-        },
-      },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Event = await fetchOneEvent(c.req.param('id'))
-    return c.json<Object>({
-      status: 'success',
-      data: Event,
-    })
-  },
 }
 
 // Untested

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -6,7 +6,7 @@ import { Context, Env } from 'hono'
 // Scrappy Doo
 import { fetchAllEvents } from '../scrapers/events/all'
 import { fetchOneEvent } from '../scrapers/events/one'
-import { fetchAllMatches } from '../scrapers/matches/all'
+import { AllMatches, fetchAllMatches } from '../scrapers/matches/all'
 import { fetchOneMatch } from '../scrapers/matches/one'
 import { fetchOnePlayer } from '../scrapers/player/one'
 import { fetchOneTeam } from '../scrapers/team/one'
@@ -14,7 +14,7 @@ import { fetchEventMatches } from '../scrapers/events/matches'
 import { generateScore } from '../scrapers/matches/score'
 
 // Schemas
-import { EventSchema, IDSchema } from '../schemas/schemas'
+import { AllMatchSchema, EventSchema, IDSchema } from '../schemas/schemas'
 
 // Types
 import { Event } from '../scrapers/events/all'
@@ -45,27 +45,31 @@ function addEventsRoute(app: OpenAPIHono<Env, {}, '/'>) {
   )
 }
 
-const MatchesRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/matches',
-    tags: ['Root Routes'],
-    description: 'Fetches all events from the vlr.gg/matches page',
-    responses: {
-      200: {
-        description: 'Fetches all events from the /matches page',
-        content: {
-          'application/json': {
-            schema: EventSchema,
+// add All Routes related to Matches
+function addMatchRoutes(app: OpenAPIHono<Env, {}, '/'>) {
+  // GET /matches
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/matches',
+      tags: ['Root Routes'],
+      description: 'Fetches all events from the vlr.gg/matches page',
+      responses: {
+        200: {
+          description: 'Fetches all events from the /matches page',
+          content: {
+            'application/json': {
+              schema: AllMatchSchema,
+            },
           },
         },
       },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Matches = await fetchAllMatches()
-    return c.json<Object>(Matches)
-  },
+    }),
+    async (c: Context) => {
+      const Matches = await fetchAllMatches()
+      return c.json<AllMatches>(Matches)
+    }
+  )
 }
 
 // Bad routes return successfully, but with empty params
@@ -338,6 +342,7 @@ const ErrorRoute = {
 
 export default function addRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   addEventsRoute(app)
+  addMatchRoutes(app)
 }
 
 /*export const Routes = [

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -26,6 +26,8 @@ import {
   teamSchema,
   eventSchema,
   Event,
+  eventMatchesSchema,
+  EventMatches,
 } from '../schemas/schemas'
 
 // Types
@@ -141,6 +143,37 @@ function addEventsRoute(app: OpenAPIHono<Env, {}, '/'>) {
     async (c: Context) => {
       const Event = await fetchOneEvent(c.req.param('id'))
       return c.json<Event>(Event)
+    }
+  )
+
+  // GET /event/{id}/matches
+  app.openapi(
+    {
+      method: 'get',
+      path: '/event/{id}/matches',
+      tags: ['Event Routes'],
+      request: {
+        params: IDSchema,
+      },
+      responses: {
+        200: {
+          description: 'Fetches matches of a specific event',
+          content: {
+            'application/json': {
+              schema: eventMatchesSchema,
+            },
+          },
+        },
+      },
+    },
+    async (c: Context) => {
+      const id = c.req.param('id')
+      // Validate input
+      // make sure id is a string of numbers
+      if (!id.match(/^[0-9]+$/)) throw new Error('Invalid ID')
+
+      const Event = await fetchEventMatches(id)
+      return c.json<EventMatches>(Event)
     }
   )
 }
@@ -268,36 +301,6 @@ function addTeamRoutes(app: OpenAPIHono<Env, {}, '/'>) {
       return c.json<Team>(Team)
     }
   )
-}
-
-// Untested
-//- Needs Schema Work
-const EventMatchesRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/event/{id}/matches',
-    tags: ['Event Routes'],
-    request: {
-      params: IDSchema,
-    },
-    responses: {
-      200: {
-        description: 'Fetches a specific event',
-        content: {
-          'application/json': {
-            schema: shortEventSchema,
-          },
-        },
-      },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Event = await fetchEventMatches(c.req.param('id'))
-    return c.json<Object>({
-      status: 'success',
-      data: Event,
-    })
-  },
 }
 
 const ScoreRoute = {

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -2,19 +2,25 @@
 import { OpenAPIHono, z } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
 import { Context, Env } from 'hono'
+import { validator } from 'hono/validator'
 
 // Scrappy Doo
 import { fetchAllEvents } from '../scrapers/events/all'
 import { fetchOneEvent } from '../scrapers/events/one'
 import { AllMatches, fetchAllMatches } from '../scrapers/matches/all'
-import { fetchOneMatch } from '../scrapers/matches/one'
+import { Match, fetchOneMatch } from '../scrapers/matches/one'
 import { fetchOnePlayer } from '../scrapers/player/one'
 import { fetchOneTeam } from '../scrapers/team/one'
 import { fetchEventMatches } from '../scrapers/events/matches'
 import { generateScore } from '../scrapers/matches/score'
 
 // Schemas
-import { AllMatchSchema, EventSchema, IDSchema } from '../schemas/schemas'
+import {
+  AllMatchSchema,
+  EventSchema,
+  IDSchema,
+  MatchSchema,
+} from '../schemas/schemas'
 
 // Types
 import { Event } from '../scrapers/events/all'
@@ -70,36 +76,38 @@ function addMatchRoutes(app: OpenAPIHono<Env, {}, '/'>) {
       return c.json<AllMatches>(Matches)
     }
   )
-}
 
-// Bad routes return successfully, but with empty params
-// This is because Matches and Form Threads are both using root ids
-// vlr.gg/{id}
-//- Needs Schema Work
-const MatchRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/match/{id}',
-    tags: ['Root Routes'],
-    request: {
-      params: IDSchema,
-    },
-    description: 'Fetches a Match based on the Match ID from vlr.gg',
-    responses: {
-      200: {
-        description: 'Fetches a Match based on the Match ID from vlr.gg',
-        content: {
-          'application/json': {
-            schema: EventSchema,
+  // GET /match/{id}
+  // Bad routes return successfully, but with empty params
+  // This is because Matches and Form Threads are both using root ids
+  // vlr.gg/{id}
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/match/{id}',
+      tags: ['Root Routes'],
+      request: {
+        params: IDSchema,
+      },
+      description: 'Fetches a Match based on the Match ID from vlr.gg',
+      responses: {
+        200: {
+          description: 'Fetches a Match based on the Match ID from vlr.gg',
+          content: {
+            'application/json': {
+              schema: MatchSchema,
+            },
           },
         },
       },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Match = await fetchOneMatch(c.req.param('id'))
-    return c.json<Object>(Match)
-  },
+    }),
+    async (c: Context) => {
+      // console.log('test')
+      // return c.json<Match>({} as Match)
+      const Match = await fetchOneMatch(c.req.param('id'))
+      return c.json<Match>(Match)
+    }
+  )
 }
 
 // Works Perfectly!

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -17,7 +17,7 @@ import { generateScore } from '../scrapers/matches/score'
 // Schemas
 import {
   AllMatchSchema,
-  EventSchema,
+  shortEventSchema,
   IDSchema,
   MatchSchema,
   Player,
@@ -27,7 +27,7 @@ import {
 } from '../schemas/schemas'
 
 // Types
-import { Event } from '../scrapers/events/all'
+import { ShortEvent } from '../scrapers/events/all'
 
 // Works Perfectly
 function addEventsRoute(app: OpenAPIHono<Env, {}, '/'>) {
@@ -42,7 +42,7 @@ function addEventsRoute(app: OpenAPIHono<Env, {}, '/'>) {
           description: 'Fetches all events from the /events page',
           content: {
             'application/json': {
-              schema: EventSchema,
+              schema: shortEventSchema,
             },
           },
         },

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -102,8 +102,9 @@ function addMatchRoutes(app: OpenAPIHono<Env, {}, '/'>) {
       },
     }),
     async (c: Context) => {
-      // console.log('test')
-      // return c.json<Match>({} as Match)
+      // validate Match ID
+      // make sure id is a string of numbers
+      if (!c.req.param('id').match(/^[0-9]+$/)) throw new Error('Invalid ID')
       const Match = await fetchOneMatch(c.req.param('id'))
       return c.json<Match>(Match)
     }

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -28,6 +28,8 @@ import {
   Event,
   eventMatchesSchema,
   EventMatches,
+  scoreSchema,
+  Score,
 } from '../schemas/schemas'
 
 // Types
@@ -303,32 +305,33 @@ function addTeamRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   )
 }
 
-const ScoreRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/score/{id}',
-    tags: ['Root Routes'],
-    request: {
-      params: IDSchema,
-    },
-    responses: {
-      200: {
-        description: 'Generates the score for a given match',
-        content: {
-          'application/json': {
-            schema: shortEventSchema,
+// add All Score Routes
+function addScoreRoutes(app: OpenAPIHono<Env, {}, '/'>) {
+  // GET /score/{id}
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/score/{id}',
+      tags: ['Root Routes'],
+      request: {
+        params: IDSchema,
+      },
+      responses: {
+        200: {
+          description: 'Generates the score for a given match',
+          content: {
+            'application/json': {
+              schema: scoreSchema,
+            },
           },
         },
       },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Score = await generateScore(c.req.param('id'))
-    return c.json<Object>({
-      status: 'success',
-      data: Score,
-    })
-  },
+    }),
+    async (c: Context) => {
+      const Score = await generateScore(c.req.param('id'))
+      return c.json<Score>(Score)
+    }
+  )
 }
 
 // Working!
@@ -371,6 +374,7 @@ export default function addRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   addMatchRoutes(app)
   addPlayerRoutes(app)
   addTeamRoutes(app)
+  addScoreRoutes(app)
 }
 
 /*export const Routes = [

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -21,7 +21,9 @@ import {
   IDSchema,
   MatchSchema,
   Player,
+  Team,
   playerSchema,
+  teamSchema,
 } from '../schemas/schemas'
 
 // Types
@@ -144,8 +146,42 @@ function addPlayerRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   )
 }
 
-// Works Perfectly!
-//- Needs Schema Work
+// add All Team Routes
+function addTeamRoutes(app: OpenAPIHono<Env, {}, '/'>) {
+  // GET /team/{id}
+  // Works Perfectly!
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/team/{id}',
+      tags: ['Root Routes'],
+      request: {
+        params: IDSchema,
+      },
+      description: 'Fetches a Team based on their ID from vlr.gg',
+      responses: {
+        200: {
+          description: 'Fetches a Team based on their ID from vlr.gg',
+          content: {
+            'application/json': {
+              schema: teamSchema,
+            },
+          },
+        },
+      },
+    }),
+    async (c: Context) => {
+      const id = c.req.param('id')
+      // Validate input
+      // make sure id is a string of numbers
+      if (!id.match(/^[0-9,]+$/)) throw new Error('Invalid ID')
+
+      const Team = await fetchOneTeam(id)
+      return c.json<Team>(Team)
+    }
+  )
+}
+
 const TeamRoute = {
   route: createRoute({
     method: 'get',
@@ -357,6 +393,7 @@ export default function addRoutes(app: OpenAPIHono<Env, {}, '/'>) {
   addEventsRoute(app)
   addMatchRoutes(app)
   addPlayerRoutes(app)
+  addTeamRoutes(app)
 }
 
 /*export const Routes = [

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,7 +1,7 @@
 // OPENAPI's FACE ya DINK
-import { z } from '@hono/zod-openapi'
+import { OpenAPIHono, z } from '@hono/zod-openapi'
 import { createRoute } from '@hono/zod-openapi'
-import { Context } from 'hono'
+import { Context, Env } from 'hono'
 
 // Scrappy Doo
 import { fetchAllEvents } from '../scrapers/events/all'
@@ -16,28 +16,33 @@ import { generateScore } from '../scrapers/matches/score'
 // Schemas
 import { EventSchema, IDSchema } from '../schemas/schemas'
 
+// Types
+import { Event } from '../scrapers/events/all'
+
 // Works Perfectly
-const EventsRoute = {
-  route: createRoute({
-    method: 'get',
-    path: '/events',
-    tags: ['Root Routes'],
-    description: 'Fetches all events from the vlr.gg/events page',
-    responses: {
-      200: {
-        description: 'Fetches all events from the /events page',
-        content: {
-          'application/json': {
-            schema: EventSchema,
+function addEventsRoute(app: OpenAPIHono<Env, {}, '/'>) {
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/events',
+      tags: ['Root Routes'],
+      description: 'Fetches all events from the vlr.gg/events page',
+      responses: {
+        200: {
+          description: 'Fetches all events from the /events page',
+          content: {
+            'application/json': {
+              schema: EventSchema,
+            },
           },
         },
       },
-    },
-  }),
-  handler: async (c: Context) => {
-    const Events = await fetchAllEvents()
-    return c.json<Object>(Events)
-  },
+    }),
+    async (c: Context) => {
+      const Events = await fetchAllEvents()
+      return c.json<Event>(Events)
+    }
+  )
 }
 
 const MatchesRoute = {
@@ -331,7 +336,11 @@ const ErrorRoute = {
   },
 }
 
-export const Routes = [
+export default function addRoutes(app: OpenAPIHono<Env, {}, '/'>) {
+  addEventsRoute(app)
+}
+
+/*export const Routes = [
   EventsRoute,
   EventRoute,
   EventPlayersRoute,
@@ -343,4 +352,4 @@ export const Routes = [
   TeamRoute,
   ErrorRoute,
   ScoreRoute,
-]
+]*/

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -13,8 +13,8 @@ export const regionsEnum = z.enum([
 export const typeEnum = z.enum(['Event', 'Match'])
 export const statusEnum = z.enum(['Upcoming', 'Ongoing', 'Completed'])
 
-// TODO: move all typeExports heare
 // Util Objects
+// TODO: add openapi examples
 // Object for the stats of a player
 const statsObject = z
   .object({
@@ -179,7 +179,53 @@ const extStatsObject = z
   })
 export type ExtStats = z.infer<typeof extStatsObject>
 
+// Object for the team used in matches
+const teamObject = z.object({
+  name: z.string().openapi({
+    example: 'Team Liquid',
+  }),
+  id: z
+    .string()
+    .min(1)
+    .regex(/^[0-9]+$/) // Only numbers
+    .openapi({
+      example: '000000000001927',
+    }),
+  score: z.string().openapi({
+    example: '13',
+  }),
+})
+export type Team = z.infer<typeof teamObject>
+
+// Object for the team used in Game
+const teamObjectExtended = teamObject.extend({
+  players: z.array(z.string()),
+  scoreAdvanced: z.object({
+    t: z.number(),
+    ct: z.number(),
+    ot: z.number(),
+  }),
+})
+export type TeamExtended = z.infer<typeof teamObjectExtended>
+
+// Object for the game used in matches
+const gameObject = z.object({
+  map: z.string().openapi({
+    example: 'Bind',
+  }),
+  teams: z.array(teamObjectExtended),
+})
+export type Game = z.infer<typeof gameObject>
+
+// Object for the stream used in matches
+const streamObject = z.object({
+  name: z.string(),
+  link: z.string(),
+})
+export type Stream = z.infer<typeof streamObject>
+
 // Schemas
+// TODO: move all typeExports heare
 const IDType = z
   .string()
   .min(1)
@@ -225,47 +271,6 @@ const EventSchema = z
     }),
   })
   .array()
-
-const teamObject = z.object({
-  name: z.string().openapi({
-    example: 'Team Liquid',
-  }),
-  id: z
-    .string()
-    .min(1)
-    .regex(/^[0-9]+$/) // Only numbers
-    .openapi({
-      example: '000000000001927',
-    }),
-  score: z.string().openapi({
-    example: '13',
-  }),
-})
-export type Team = z.infer<typeof teamObject>
-
-const teamObjectExtended = teamObject.extend({
-  players: z.array(z.string()),
-  scoreAdvanced: z.object({
-    t: z.number(),
-    ct: z.number(),
-    ot: z.number(),
-  }),
-})
-export type TeamExtended = z.infer<typeof teamObjectExtended>
-
-const gameObject = z.object({
-  map: z.string().openapi({
-    example: 'Bind',
-  }),
-  teams: z.array(teamObjectExtended),
-})
-export type Game = z.infer<typeof gameObject>
-
-const streamObject = z.object({
-  name: z.string(),
-  link: z.string(),
-})
-export type Stream = z.infer<typeof streamObject>
 
 const playerSchema = z.object({
   name: z.string(),

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -1,5 +1,9 @@
 import { z } from '@hono/zod-openapi'
 
+// Enums
+const regionsEnum = z.enum(['EU', 'NA', 'KR', 'BR', 'AP', 'LATAM', 'OCE'])
+
+// Types
 const IDType = z
   .string()
   .min(1)
@@ -37,12 +41,9 @@ const EventSchema = z
     prize: z.string().openapi({
       example: '$250,000',
     }),
-    region: z
-      .string()
-      .regex(/EU||NA||KR||BR||AP||LATAM||OCE/)
-      .openapi({
-        example: 'EU',
-      }),
+    region: regionsEnum.openapi({
+      example: 'EU',
+    }),
     logo: z.string().openapi({
       example: 'https://owcdn.net/img/6009f963577f4.png',
     }),
@@ -78,6 +79,7 @@ const PlayerSchema = z.object({
   name: z.string(),
   link: z.string(),
 })
+// Schema for the /matches/{id} endpoint
 const MatchSchema = z.object({
   type: z.string().openapi({
     example: 'Match',
@@ -115,12 +117,9 @@ const MatchSchema = z.object({
   prize: z.string().openapi({
     example: '$250,000',
   }),
-  region: z
-    .string()
-    .regex(/EU||NA||KR||BR||AP||LATAM||OCE/)
-    .openapi({
-      example: 'EU',
-    }),
+  region: regionsEnum.openapi({
+    example: 'EU',
+  }),
   logo: z.string().openapi({
     example: 'https://owcdn.net/img/6009f963577f4.png',
   }),

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -12,40 +12,42 @@ const IDSchema = z.object({
   id: IDType,
 })
 
-const EventSchema = z.object({
-  type: z.string().openapi({
-    example: 'Event',
-  }),
-  id: IDType,
-  link: z.string().openapi({
-    example:
-      'https://www.vlr.gg/event/1927/champions-tour-2023-china-ascension',
-  }),
-  name: z.string().openapi({
-    example: 'Champions Tour 2023 China: Ascension',
-  }),
-  date: z.string().openapi({
-    example: 'Dec 22—30',
-  }),
-  status: z
-    .string()
-    .regex(/New||Ongoing||Completed/)
-    .openapi({
-      example: 'completed',
+const EventSchema = z
+  .object({
+    type: z.string().openapi({
+      example: 'Event',
     }),
-  prize: z.string().openapi({
-    example: '$250,000',
-  }),
-  region: z
-    .string()
-    .regex(/EU||NA||KR||BR||AP||LATAM||OCE/)
-    .openapi({
-      example: 'EU',
+    id: IDType,
+    link: z.string().openapi({
+      example:
+        'https://www.vlr.gg/event/1927/champions-tour-2023-china-ascension',
     }),
-  logo: z.string().openapi({
-    example: 'https://owcdn.net/img/6009f963577f4.png',
-  }),
-})
+    name: z.string().openapi({
+      example: 'Champions Tour 2023 China: Ascension',
+    }),
+    date: z.string().openapi({
+      example: 'Dec 22—30',
+    }),
+    status: z
+      .string()
+      .regex(/New||Ongoing||Completed/)
+      .openapi({
+        example: 'completed',
+      }),
+    prize: z.string().openapi({
+      example: '$250,000',
+    }),
+    region: z
+      .string()
+      .regex(/EU||NA||KR||BR||AP||LATAM||OCE/)
+      .openapi({
+        example: 'EU',
+      }),
+    logo: z.string().openapi({
+      example: 'https://owcdn.net/img/6009f963577f4.png',
+    }),
+  })
+  .array()
 
 const TeamSchema = z.object({
   name: z.string().openapi({
@@ -70,11 +72,11 @@ const GameSchema = z.object({
 })
 const StreamSchema = z.object({
   name: z.string(),
-  link: z.string()
+  link: z.string(),
 })
 const PlayerSchema = z.object({
   name: z.string(),
-  link: z.string()
+  link: z.string(),
 })
 const MatchSchema = z.object({
   type: z.string().openapi({

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -363,6 +363,29 @@ export const playerSchema = z.object({
 })
 export type Player = z.infer<typeof playerSchema>
 
+// Schema for the /teams/{id} endpoint
+export const teamSchema = z.object({
+  id: IDType,
+  name: z.string(),
+  tag: z.string(),
+  logo: z.string(),
+  country: z.string(),
+  link: z.string(),
+  socials: z.array(z.object({ name: z.string(), link: z.string() })),
+  earnings: z.string(),
+  players: z.array(playerSchema),
+  staff: z.array(z.string()),
+  staff_item: z.array(
+    z.object({
+      ign: z.string(),
+      link: z.string(),
+      id: IDType,
+      role: z.string(),
+    })
+  ),
+})
+export type Team = z.infer<typeof teamSchema>
+
 // Schema for the /matches/{id} endpoint
 export const MatchSchema = z.object({
   type: typeEnum.openapi({

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -516,4 +516,11 @@ export const scoreSchema = z.object({
 })
 export type Score = z.infer<typeof scoreSchema>
 
+// Schema for error endpoint
+export const errorSchema = z.object({
+  status: z.string().openapi({ example: 'error' }),
+  message: z.string().openapi({ example: 'Error: 404' }),
+})
+export type ErrorSchema = z.infer<typeof errorSchema>
+
 export { IDSchema }

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -286,7 +286,7 @@ const IDSchema = z.object({
 })
 
 // Schema for the /events endpoint
-export const EventSchema = z
+export const shortEventSchema = z
   .object({
     type: typeEnum.openapi({
       example: 'Event',

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -224,6 +224,20 @@ const streamObject = z.object({
 })
 export type Stream = z.infer<typeof streamObject>
 
+export const playerMatchStatsObject = z.object({
+  name: z.string(),
+  team: z.string(),
+  link: z.string(),
+  stats: statsObject,
+  statsAdvanced: extStatsObject,
+})
+export const playerMatchStatsArraySchema = playerMatchStatsObject.array()
+
+export type PlayerMatchStats = z.infer<typeof playerMatchStatsArraySchema>
+export type PlayerMatchStatsElement = z.infer<
+  typeof playerMatchStatsArraySchema.element
+>
+
 // Schemas
 // TODO: move all typeExports heare
 const IDType = z
@@ -313,7 +327,7 @@ const MatchSchema = z.object({
   }),
   games: z.array(gameObject),
   teams: z.array(teamObject),
-  players: z.array(playerSchema),
+  players: playerMatchStatsArraySchema,
 })
 // Schema for the /matches endpoint
 export const AllMatchSchema = z

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -16,7 +16,7 @@ export const statusEnum = z.enum(['Upcoming', 'Ongoing', 'Completed'])
 // Util Objects
 // TODO: add openapi examples
 // Object for the stats of a player
-const statsObject = z
+const playerStatsObject = z
   .object({
     kdr: z.string(),
     acs: z.string(),
@@ -47,7 +47,7 @@ const statsObject = z
       fkdb: '0',
     },
   })
-export type Stats = z.infer<typeof statsObject>
+export type PlayerStats = z.infer<typeof playerStatsObject>
 
 // Object for the stats of a player per site
 const extStatsObject = z
@@ -228,7 +228,7 @@ export const playerMatchStatsObject = z.object({
   name: z.string(),
   team: z.string(),
   link: z.string(),
-  stats: statsObject,
+  stats: playerStatsObject,
   statsAdvanced: extStatsObject,
 })
 export const playerMatchStatsArraySchema = playerMatchStatsObject.array()

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -257,20 +257,18 @@ const streamObject = z.object({
 })
 export type Stream = z.infer<typeof streamObject>
 
-// Object for the player stats in a match
-export const playerMatchStatsObject = z
-  .object({
-    name: z.string(),
-    team: z.string(),
-    link: z.string(),
-    stats: playerStatsObject,
-    statsAdvanced: extStatsObject,
-  })
-  .array()
+export const playerMatchStatsObject = z.object({
+  name: z.string(),
+  team: z.string(),
+  link: z.string(),
+  stats: playerStatsObject,
+  statsAdvanced: extStatsObject,
+})
+export const playerMatchStatsArraySchema = playerMatchStatsObject.array()
 
-export type PlayerMatchStats = z.infer<typeof playerMatchStatsObject>
+export type PlayerMatchStats = z.infer<typeof playerMatchStatsArraySchema>
 export type PlayerMatchStatsElement = z.infer<
-  typeof playerMatchStatsObject.element
+  typeof playerMatchStatsArraySchema.element
 >
 
 // Schemas

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -285,6 +285,42 @@ const IDSchema = z.object({
   id: IDType,
 })
 
+// Schema for the /matches/{id} endpoint
+export const MatchSchema = z.object({
+  type: typeEnum.openapi({
+    example: 'Event',
+  }),
+  id: z
+    .string()
+    .min(1)
+    .regex(/^[0-9]+$/) // Only numbers
+    .openapi({
+      example: '000000000001927',
+    }),
+  link: z.string().openapi({
+    example:
+      'https://www.vlr.gg/314629/sentinels-vs-leviat-n-champions-tour-2024-americas-stage-1-w2/?game=163369&tab=overview',
+  }),
+  date: z.string().openapi({
+    example: 'Dec 22—30',
+  }),
+  time: z.string().openapi({
+    example: '1:25 AM CEST',
+  }),
+  eventId: IDType, // ID or 0
+  eventName: z.string(),
+  logo: z.string().openapi({
+    example: 'https://owcdn.net/img/6009f963577f4.png',
+  }),
+  streams: z.array(streamObject),
+  status: statusEnum.openapi({
+    example: statusEnum.enum.Completed,
+  }),
+  games: z.array(gameObject),
+  teams: z.array(gameTeamObject),
+  players: playerMatchStatsArraySchema,
+})
+
 // Schema for the /events endpoint
 export const shortEventSchema = z
   .object({
@@ -436,42 +472,6 @@ export const teamSchema = z.object({
   ),
 })
 export type Team = z.infer<typeof teamSchema>
-
-// Schema for the /matches/{id} endpoint
-export const MatchSchema = z.object({
-  type: typeEnum.openapi({
-    example: 'Event',
-  }),
-  id: z
-    .string()
-    .min(1)
-    .regex(/^[0-9]+$/) // Only numbers
-    .openapi({
-      example: '000000000001927',
-    }),
-  link: z.string().openapi({
-    example:
-      'https://www.vlr.gg/314629/sentinels-vs-leviat-n-champions-tour-2024-americas-stage-1-w2/?game=163369&tab=overview',
-  }),
-  date: z.string().openapi({
-    example: 'Dec 22—30',
-  }),
-  time: z.string().openapi({
-    example: '1:25 AM CEST',
-  }),
-  eventId: IDType, // ID or 0
-  eventName: z.string(),
-  logo: z.string().openapi({
-    example: 'https://owcdn.net/img/6009f963577f4.png',
-  }),
-  streams: z.array(streamObject),
-  status: statusEnum.openapi({
-    example: statusEnum.enum.Completed,
-  }),
-  games: z.array(gameObject),
-  teams: z.array(gameTeamObject),
-  players: playerMatchStatsArraySchema,
-})
 
 // Schema for the /matches endpoint
 export const AllMatchSchema = z

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -13,6 +13,7 @@ export const regionsEnum = z.enum([
 export const typeEnum = z.enum(['Event', 'Match'])
 export const statusEnum = z.enum(['Upcoming', 'Ongoing', 'Completed'])
 
+// TODO: move all typeExports heare
 // Util Objects
 // Object for the stats of a player
 const statsObject = z
@@ -225,7 +226,7 @@ const EventSchema = z
   })
   .array()
 
-const TeamSchema = z.object({
+const teamObject = z.object({
   name: z.string().openapi({
     example: 'Team Liquid',
   }),
@@ -236,24 +237,44 @@ const TeamSchema = z.object({
     .openapi({
       example: '000000000001927',
     }),
-  mapScore: z.string().openapi({
+  score: z.string().openapi({
     example: '13',
   }),
 })
-const GameSchema = z.object({
+export type Team = z.infer<typeof teamObject>
+
+const teamObjectExtended = teamObject.extend({
+  players: z.array(z.string()),
+  scoreAdvanced: z.object({
+    t: z.number(),
+    ct: z.number(),
+    ot: z.number(),
+  }),
+})
+export type TeamExtended = z.infer<typeof teamObjectExtended>
+
+const gameObject = z.object({
   map: z.string().openapi({
     example: 'Bind',
   }),
-  teams: z.array(TeamSchema),
+  teams: z.array(teamObjectExtended),
 })
-const StreamSchema = z.object({
+export type Game = z.infer<typeof gameObject>
+
+const streamObject = z.object({
   name: z.string(),
   link: z.string(),
 })
-const PlayerSchema = z.object({
+export type Stream = z.infer<typeof streamObject>
+
+const playerSchema = z.object({
   name: z.string(),
+  team: z.string(),
   link: z.string(),
+  stats: statsObject,
+  statsAdvanced: extStatsObject,
 })
+export type Player = z.infer<typeof playerSchema>
 // Schema for the /matches/{id} endpoint
 const MatchSchema = z.object({
   type: typeEnum.openapi({
@@ -266,37 +287,30 @@ const MatchSchema = z.object({
     .openapi({
       example: '000000000001927',
     }),
-  time: z.string(),
-  event: z.string(), // ID or 0
-  eventname: z.string(),
-  streams: z.array(StreamSchema),
-  players: z.array(PlayerSchema),
-  games: z.array(GameSchema),
-  teams: z.array(TeamSchema),
+  date: z.string().openapi({
+    example: 'Dec 22—30',
+  }),
+  time: z.string().openapi({
+    example: '1:25 AM CEST',
+  }),
+  eventId: IDType, // ID or 0
+  eventName: z.string(),
+  logo: z.string().openapi({
+    example: 'https://owcdn.net/img/6009f963577f4.png',
+  }),
+  streams: z.array(streamObject),
+  status: statusEnum.openapi({
+    example: statusEnum.enum.Completed,
+  }),
+  games: z.array(gameObject),
+  teams: z.array(teamObject),
+  players: z.array(playerSchema),
   link: z.string().openapi({
     example:
       'https://www.vlr.gg/event/1927/champions-tour-2023-china-ascension',
   }),
   name: z.string().openapi({
     example: 'Champions Tour 2023 China: Ascension',
-  }),
-  date: z.string().openapi({
-    example: 'Dec 22—30',
-  }),
-  status: z
-    .string()
-    .regex(/New||Ongoing||Completed/)
-    .openapi({
-      example: 'completed',
-    }),
-  prize: z.string().openapi({
-    example: '$250,000',
-  }),
-  region: regionsEnum.openapi({
-    example: 'EU',
-  }),
-  logo: z.string().openapi({
-    example: 'https://owcdn.net/img/6009f963577f4.png',
   }),
 })
 // Schema for the /matches endpoint

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -321,6 +321,15 @@ export const MatchSchema = z.object({
   players: playerMatchStatsArraySchema,
 })
 
+// Schema for the /matches endpoint
+export const AllMatchSchema = z
+  .object({
+    date: z.string(),
+    today: z.boolean(),
+    matches: z.array(MatchSchema),
+  })
+  .array()
+
 // Schema for the /events endpoint
 export const shortEventSchema = z
   .object({
@@ -492,14 +501,5 @@ export const teamSchema = z.object({
   ),
 })
 export type Team = z.infer<typeof teamSchema>
-
-// Schema for the /matches endpoint
-export const AllMatchSchema = z
-  .object({
-    date: z.string(),
-    today: z.boolean(),
-    matches: z.array(MatchSchema),
-  })
-  .array()
 
 export { IDSchema }

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -125,5 +125,13 @@ const MatchSchema = z.object({
     example: 'https://owcdn.net/img/6009f963577f4.png',
   }),
 })
+// Schema for the /matches endpoint
+export const AllMatchSchema = z
+  .object({
+    date: z.string(),
+    today: z.boolean(),
+    matches: z.array(MatchSchema),
+  })
+  .array()
 
 export { IDSchema, EventSchema, MatchSchema }

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -407,6 +407,26 @@ export const eventSchema = z.object({
 })
 export type Event = z.infer<typeof eventSchema>
 
+// Schema for the /event/{id}/match endpoint
+export const eventMatchesSchema = z.object({
+  type: typeEnum.openapi({
+    example: 'Event',
+  }),
+  name: z.string().openapi({
+    example: 'Champions Tour 2023 China: Ascension',
+  }),
+  link: z.string().openapi({
+    example:
+      'https://www.vlr.gg/event/1927/champions-tour-2023-china-ascension',
+  }),
+  id: IDType,
+  img: z.string().openapi({
+    example: 'https://owcdn.net/img/6009f963577f4.png',
+  }),
+  matches: MatchSchema.array(),
+})
+export type EventMatches = z.infer<typeof eventMatchesSchema>
+
 // Schema for the /players/{id} endpoint
 export const playerSchema = z.object({
   ign: z.string(),

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -502,4 +502,18 @@ export const teamSchema = z.object({
 })
 export type Team = z.infer<typeof teamSchema>
 
+// Schema for the /score/{id} endpoint
+export const scoreSchema = z.object({
+  id: IDType,
+  scores_array: z.array(
+    z.object({
+      name: z.string(),
+      score: z.number(),
+    })
+  ),
+  scores_object: z.record(z.string(), z.number()),
+  match: MatchSchema,
+})
+export type Score = z.infer<typeof scoreSchema>
+
 export { IDSchema }

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -257,18 +257,20 @@ const streamObject = z.object({
 })
 export type Stream = z.infer<typeof streamObject>
 
-export const playerMatchStatsObject = z.object({
-  name: z.string(),
-  team: z.string(),
-  link: z.string(),
-  stats: playerStatsObject,
-  statsAdvanced: extStatsObject,
-})
-export const playerMatchStatsArraySchema = playerMatchStatsObject.array()
+// Object for the player stats in a match
+export const playerMatchStatsObject = z
+  .object({
+    name: z.string(),
+    team: z.string(),
+    link: z.string(),
+    stats: playerStatsObject,
+    statsAdvanced: extStatsObject,
+  })
+  .array()
 
-export type PlayerMatchStats = z.infer<typeof playerMatchStatsArraySchema>
+export type PlayerMatchStats = z.infer<typeof playerMatchStatsObject>
 export type PlayerMatchStatsElement = z.infer<
-  typeof playerMatchStatsArraySchema.element
+  typeof playerMatchStatsObject.element
 >
 
 // Schemas

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -11,6 +11,7 @@ export const regionsEnum = z.enum([
   'OCE',
 ])
 export const typeEnum = z.enum(['Event', 'Match'])
+export const statusEnum = z.enum(['Upcoming', 'Ongoing', 'Completed'])
 
 // Util Objects
 // Object for the stats of a player

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -1,8 +1,16 @@
 import { z } from '@hono/zod-openapi'
 
 // Enums
-const regionsEnum = z.enum(['EU', 'NA', 'KR', 'BR', 'AP', 'LATAM', 'OCE'])
-const typeEnum = z.enum(['Event', 'Match'])
+export const regionsEnum = z.enum([
+  'EU',
+  'NA',
+  'KR',
+  'BR',
+  'AP',
+  'LATAM',
+  'OCE',
+])
+export const typeEnum = z.enum(['Event', 'Match'])
 
 // Types
 const IDType = z

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -10,7 +10,7 @@ export const regionsEnum = z.enum([
   'LATAM',
   'OCE',
 ])
-export const typeEnum = z.enum(['Event', 'Match'])
+export const typeEnum = z.enum(['Event', 'Match', 'Player', 'Team'])
 export const statusEnum = z.enum(['Upcoming', 'Ongoing', 'Completed'])
 export const timeEnum = z.enum(['t30', 't60', 't90', 'tall'])
 
@@ -319,6 +319,57 @@ export const shortEventSchema = z
     }),
   })
   .array()
+
+// Schema for the /event/{id} endpoint
+export const eventSchema = z.object({
+  type: typeEnum.openapi({
+    example: 'Event',
+  }),
+  id: IDType,
+  name: z.string().openapi({
+    example: 'Champions Tour 2023 China: Ascension',
+  }),
+  link: z.string().openapi({
+    example:
+      'https://www.vlr.gg/event/1927/champions-tour-2023-china-ascension',
+  }),
+  logo: z.string().openapi({
+    example: 'https://owcdn.net/img/6009f963577f4.png',
+  }),
+  teams_item: z.array(
+    z.object({
+      name: z.string(),
+      logo: z.string(),
+      link: z.string(),
+      id: IDType,
+      players: z.array(
+        z.object({
+          type: typeEnum,
+          ign: z.string(),
+          link: z.string(),
+          id: IDType,
+        })
+      ),
+      status: z.string(),
+    })
+  ),
+  players_item: z.array(
+    z.object({
+      type: typeEnum,
+      ign: z.string(),
+      name: z.string(),
+      link: z.string(),
+      id: IDType,
+      team: z.object({
+        type: typeEnum,
+        name: z.string(),
+        id: IDType,
+      }),
+    })
+  ),
+  failed_links: z.array(z.string()),
+})
+export type Event = z.infer<typeof eventSchema>
 
 // Schema for the /players/{id} endpoint
 export const playerSchema = z.object({

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -213,7 +213,7 @@ export const playerAgentStatsObject = z.object({
 export type PlayerAgentStats = z.infer<typeof playerAgentStatsObject>
 
 // Object for the team used in matches
-const teamObject = z.object({
+const gameTeamObject = z.object({
   name: z.string().openapi({
     example: 'Team Liquid',
   }),
@@ -228,10 +228,10 @@ const teamObject = z.object({
     example: '13',
   }),
 })
-export type Team = z.infer<typeof teamObject>
+export type GameTeam = z.infer<typeof gameTeamObject>
 
 // Object for the team used in Game
-const teamObjectExtended = teamObject.extend({
+const gameTeamExtendedObject = gameTeamObject.extend({
   players: z.array(z.string()),
   scoreAdvanced: z.object({
     t: z.number(),
@@ -239,14 +239,14 @@ const teamObjectExtended = teamObject.extend({
     ot: z.number(),
   }),
 })
-export type TeamExtended = z.infer<typeof teamObjectExtended>
+export type GameTeamExtended = z.infer<typeof gameTeamExtendedObject>
 
 // Object for the game used in matches
 const gameObject = z.object({
   map: z.string().openapi({
     example: 'Bind',
   }),
-  teams: z.array(teamObjectExtended),
+  teams: z.array(gameTeamExtendedObject),
 })
 export type Game = z.infer<typeof gameObject>
 
@@ -395,9 +395,10 @@ export const MatchSchema = z.object({
     example: statusEnum.enum.Completed,
   }),
   games: z.array(gameObject),
-  teams: z.array(teamObject),
+  teams: z.array(gameTeamObject),
   players: playerMatchStatsArraySchema,
 })
+
 // Schema for the /matches endpoint
 export const AllMatchSchema = z
   .object({

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -12,7 +12,172 @@ export const regionsEnum = z.enum([
 ])
 export const typeEnum = z.enum(['Event', 'Match'])
 
-// Types
+// Util Objects
+// Object for the stats of a player
+const statsObject = z
+  .object({
+    kdr: z.string(),
+    acs: z.string(),
+    k: z.string(),
+    d: z.string(),
+    a: z.string(),
+    kdb: z.string(),
+    kast: z.string(),
+    adr: z.string(),
+    hs: z.string(),
+    fk: z.string(),
+    fd: z.string(),
+    fkdb: z.string(),
+  })
+  .openapi({
+    example: {
+      kdr: '1.20',
+      acs: '230',
+      k: '29',
+      d: '21',
+      a: '6',
+      kdb: '+8',
+      kast: '69%',
+      adr: '162',
+      hs: '37%',
+      fk: '2',
+      fd: '2',
+      fkdb: '0',
+    },
+  })
+export type Stats = z.infer<typeof statsObject>
+
+// Object for the stats of a player per site
+const extStatsObject = z
+  .object({
+    kdr: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    acs: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    k: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    d: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    a: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    kdb: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    kast: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    adr: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    hs: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    fk: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    fd: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+    fkdb: z.object({
+      ct: z.string(),
+      t: z.string(),
+      ot: z.string(),
+    }),
+  })
+  .openapi({
+    example: {
+      kdr: {
+        ct: '0.88',
+        t: '1.51',
+        ot: '',
+      },
+      acs: {
+        ct: '127',
+        t: '334',
+        ot: '',
+      },
+      k: {
+        ct: '7',
+        t: '22',
+        ot: '',
+      },
+      d: {
+        ct: '11',
+        t: '10',
+        ot: '',
+      },
+      a: {
+        ct: '2',
+        t: '4',
+        ot: '',
+      },
+      kdb: {
+        ct: '-4',
+        t: '+12',
+        ot: '',
+      },
+      kast: {
+        ct: '56%',
+        t: '83%',
+        ot: '',
+      },
+      adr: {
+        ct: '108',
+        t: '216',
+        ot: '',
+      },
+      hs: {
+        ct: '40%',
+        t: '35%',
+        ot: '',
+      },
+      fk: {
+        ct: '0',
+        t: '2',
+        ot: '',
+      },
+      fd: {
+        ct: '1',
+        t: '1',
+        ot: '',
+      },
+      fkdb: {
+        ct: '-1',
+        t: '+1',
+        ot: '',
+      },
+    },
+  })
+export type ExtStats = z.infer<typeof extStatsObject>
+
+// Schemas
 const IDType = z
   .string()
   .min(1)

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -2,6 +2,7 @@ import { z } from '@hono/zod-openapi'
 
 // Enums
 const regionsEnum = z.enum(['EU', 'NA', 'KR', 'BR', 'AP', 'LATAM', 'OCE'])
+const typeEnum = z.enum(['Event', 'Match'])
 
 // Types
 const IDType = z
@@ -18,7 +19,7 @@ const IDSchema = z.object({
 
 const EventSchema = z
   .object({
-    type: z.string().openapi({
+    type: typeEnum.openapi({
       example: 'Event',
     }),
     id: IDType,
@@ -81,8 +82,8 @@ const PlayerSchema = z.object({
 })
 // Schema for the /matches/{id} endpoint
 const MatchSchema = z.object({
-  type: z.string().openapi({
-    example: 'Match',
+  type: typeEnum.openapi({
+    example: 'Event',
   }),
   id: z
     .string()

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -12,6 +12,7 @@ export const regionsEnum = z.enum([
 ])
 export const typeEnum = z.enum(['Event', 'Match'])
 export const statusEnum = z.enum(['Upcoming', 'Ongoing', 'Completed'])
+export const timeEnum = z.enum(['t30', 't60', 't90', 'tall'])
 
 // Util Objects
 // TODO: add openapi examples
@@ -179,6 +180,38 @@ const extStatsObject = z
   })
 export type ExtStats = z.infer<typeof extStatsObject>
 
+// Object for agentstats
+// TODO: change string to number when possible
+const agentStatsObject = z.object({
+  Agent: z.string(),
+  Use: z.string(),
+  RND: z.string(),
+  Rating: z.string(),
+  ACS: z.string(),
+  'K:D': z.string(),
+  ADR: z.string(),
+  KAST: z.string(),
+  KPR: z.string(),
+  APR: z.string(),
+  FKPR: z.string(),
+  FDPR: z.string(),
+  K: z.string(),
+  D: z.string(),
+  A: z.string(),
+  FK: z.string(),
+  FD: z.string(),
+})
+export type AgentStats = z.infer<typeof agentStatsObject>
+
+// Object for the player stats of top agents
+export const playerAgentStatsObject = z.object({
+  labels: z.array(z.string()),
+  time: timeEnum,
+  times: z.array(z.string()),
+  data: z.array(agentStatsObject),
+})
+export type PlayerAgentStats = z.infer<typeof playerAgentStatsObject>
+
 // Object for the team used in matches
 const teamObject = z.object({
   name: z.string().openapi({
@@ -252,7 +285,8 @@ const IDSchema = z.object({
   id: IDType,
 })
 
-const EventSchema = z
+// Schema for the /events endpoint
+export const EventSchema = z
   .object({
     type: typeEnum.openapi({
       example: 'Event',
@@ -286,16 +320,51 @@ const EventSchema = z
   })
   .array()
 
-const playerSchema = z.object({
+// Schema for the /players/{id} endpoint
+export const playerSchema = z.object({
+  ign: z.string(),
   name: z.string(),
-  team: z.string(),
+  realName: z.string(),
+  id: IDType,
   link: z.string(),
-  stats: statsObject,
-  statsAdvanced: extStatsObject,
+  photo: z.string(),
+  country: z.string(),
+  team: IDType.optional(),
+  role: z.string(),
+  earnings: z.string(),
+  stats: playerAgentStatsObject,
+  agentStats: z.object({
+    // TODO: find a way to automate this with the agentArray
+    astra: agentStatsObject,
+    breach: agentStatsObject,
+    brimstone: agentStatsObject,
+    chamber: agentStatsObject,
+    clove: agentStatsObject,
+    cypher: agentStatsObject,
+    deadlock: agentStatsObject,
+    fade: agentStatsObject,
+    gekko: agentStatsObject,
+    harbor: agentStatsObject,
+    iso: agentStatsObject,
+    jett: agentStatsObject,
+    kayo: agentStatsObject,
+    killjoy: agentStatsObject,
+    neon: agentStatsObject,
+    omen: agentStatsObject,
+    phoenix: agentStatsObject,
+    raze: agentStatsObject,
+    reyna: agentStatsObject,
+    sage: agentStatsObject,
+    skye: agentStatsObject,
+    sova: agentStatsObject,
+    viper: agentStatsObject,
+    yoru: agentStatsObject,
+  }),
 })
 export type Player = z.infer<typeof playerSchema>
+
 // Schema for the /matches/{id} endpoint
-const MatchSchema = z.object({
+export const MatchSchema = z.object({
   type: typeEnum.openapi({
     example: 'Event',
   }),
@@ -338,4 +407,4 @@ export const AllMatchSchema = z
   })
   .array()
 
-export { IDSchema, EventSchema, MatchSchema }
+export { IDSchema }

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -292,6 +292,10 @@ const MatchSchema = z.object({
     .openapi({
       example: '000000000001927',
     }),
+  link: z.string().openapi({
+    example:
+      'https://www.vlr.gg/314629/sentinels-vs-leviat-n-champions-tour-2024-americas-stage-1-w2/?game=163369&tab=overview',
+  }),
   date: z.string().openapi({
     example: 'Dec 22—30',
   }),
@@ -310,13 +314,6 @@ const MatchSchema = z.object({
   games: z.array(gameObject),
   teams: z.array(teamObject),
   players: z.array(playerSchema),
-  link: z.string().openapi({
-    example:
-      'https://www.vlr.gg/event/1927/champions-tour-2023-china-ascension',
-  }),
-  name: z.string().openapi({
-    example: 'Champions Tour 2023 China: Ascension',
-  }),
 })
 // Schema for the /matches endpoint
 export const AllMatchSchema = z

--- a/src/scrapers/events/all.ts
+++ b/src/scrapers/events/all.ts
@@ -5,7 +5,7 @@ import { load } from 'cheerio'
 import { idGenerator } from '../util'
 // Schema
 import { z } from '@hono/zod-openapi'
-import { EventSchema } from '../../schemas/schemas'
+import { EventSchema, regionsEnum, typeEnum } from '../../schemas/schemas'
 // Type
 export type Event = z.infer<typeof EventSchema>
 export type EventElement = z.infer<typeof EventSchema.element>
@@ -19,7 +19,7 @@ const fetchAllEvents = (page: number = 1): Promise<Event> => {
         const $ = load(data)
         $('.event-item').each((i, element) => {
           const Event = {} as EventElement
-          Event.type = 'event'
+          Event.type = typeEnum.parse('Event')
           Event.link = `https://www.vlr.gg` + $(element).attr('href')
           Event.id = idGenerator(Event.link.split('/')[4])
           Event.name = $(element).find('.event-item-title').text().trim()
@@ -37,13 +37,14 @@ const fetchAllEvents = (page: number = 1): Promise<Event> => {
             .text()
             .trim()
             .split('\t')[0]
-          Event.region =
+          Event.region = regionsEnum.parse(
             $(element)
               .find('.event-item-desc-item.mod-location > i')
               .attr('class')
               ?.split(' ')[1]
               .split('-')[1]
-              .toUpperCase() || ''
+              .toUpperCase()
+          )
           Event.logo =
             'https:' + $(element).find('.event-item-thumb > img').attr('src')
           if (!Event.logo.includes('https://')) {

--- a/src/scrapers/events/all.ts
+++ b/src/scrapers/events/all.ts
@@ -7,17 +7,18 @@ import { idGenerator } from '../util'
 import { z } from '@hono/zod-openapi'
 import { EventSchema } from '../../schemas/schemas'
 // Type
-type Event = z.infer<typeof EventSchema>
+export type Event = z.infer<typeof EventSchema>
+export type EventElement = z.infer<typeof EventSchema.element>
 
-const fetchAllEvents = (page: number = 1): Promise<Object> => {
+const fetchAllEvents = (page: number = 1): Promise<Event> => {
   return new Promise((resolve, reject) => {
-    const Events: Array<Event> = []
+    const Events: Event = []
     fetch(`https://www.vlr.gg/events/?page=${page}`)
       .then((response) => response.text())
       .then((data) => {
         const $ = load(data)
         $('.event-item').each((i, element) => {
-          const Event = {} as Event
+          const Event = {} as EventElement
           Event.type = 'event'
           Event.link = `https://www.vlr.gg` + $(element).attr('href')
           Event.id = idGenerator(Event.link.split('/')[4])

--- a/src/scrapers/events/all.ts
+++ b/src/scrapers/events/all.ts
@@ -19,7 +19,7 @@ const fetchAllEvents = (page: number = 1): Promise<Event> => {
         const $ = load(data)
         $('.event-item').each((i, element) => {
           const Event = {} as EventElement
-          Event.type = typeEnum.parse('Event')
+          Event.type = typeEnum.Enum.Event
           Event.link = `https://www.vlr.gg` + $(element).attr('href')
           Event.id = idGenerator(Event.link.split('/')[4])
           Event.name = $(element).find('.event-item-title').text().trim()

--- a/src/scrapers/events/all.ts
+++ b/src/scrapers/events/all.ts
@@ -5,20 +5,20 @@ import { load } from 'cheerio'
 import { idGenerator } from '../util'
 // Schema
 import { z } from '@hono/zod-openapi'
-import { EventSchema, regionsEnum, typeEnum } from '../../schemas/schemas'
+import { shortEventSchema, regionsEnum, typeEnum } from '../../schemas/schemas'
 // Type
-export type Event = z.infer<typeof EventSchema>
-export type EventElement = z.infer<typeof EventSchema.element>
+export type ShortEvent = z.infer<typeof shortEventSchema>
+export type ShortEventElement = z.infer<typeof shortEventSchema.element>
 
-const fetchAllEvents = (page: number = 1): Promise<Event> => {
+const fetchAllEvents = (page: number = 1): Promise<ShortEvent> => {
   return new Promise((resolve, reject) => {
-    const Events: Event = []
+    const Events: ShortEvent = []
     fetch(`https://www.vlr.gg/events/?page=${page}`)
       .then((response) => response.text())
       .then((data) => {
         const $ = load(data)
         $('.event-item').each((i, element) => {
-          const Event = {} as EventElement
+          const Event = {} as ShortEventElement
           Event.type = typeEnum.Enum.Event
           Event.link = `https://www.vlr.gg` + $(element).attr('href')
           Event.id = idGenerator(Event.link.split('/')[4])

--- a/src/scrapers/events/matches.ts
+++ b/src/scrapers/events/matches.ts
@@ -4,17 +4,10 @@
 import { load } from 'cheerio'
 import { idGenerator } from '../util'
 // Schema
-import { z } from '@hono/zod-openapi'
-import { shortEventSchema } from '../../schemas/schemas'
-import { fetchOneMatch } from '../matches/one'
-import { generateScore } from '../matches/score'
-// Type
-type Event = z.infer<typeof shortEventSchema>
+import { EventMatches, typeEnum } from '../../schemas/schemas'
+import { PORT } from '../..'
 
-const fetchEventMatches = async (id: string): Promise<Object> => {
-  // Validate input
-  // make sure id is a string of numbers
-  if (!id.match(/^[0-9]+$/)) throw new Error('Invalid ID')
+const fetchEventMatches = async (id: string): Promise<EventMatches> => {
   return new Promise(async (resolve, reject) => {
     // fetch the page
     fetch(`https://www.vlr.gg/event/matches/${id}`)
@@ -28,20 +21,20 @@ const fetchEventMatches = async (id: string): Promise<Object> => {
             .includes('Page not found')
         )
           reject('404')
-        const Event = {} as Event
-        Event.type = 'event'
+        const Event = {} as EventMatches
+        Event.type = typeEnum.Enum.Event
         Event.name = $('h1.wf-title').text().trim()
         Event.link = `https://www.vlr.gg/event/${id}`
-        Event.id = id
+        Event.id = idGenerator(id)
         Event.img =
           'https:' + $('.wf-avatar.event-header-thumb img').attr('src')
 
         // Pull all match IDs
-        const MatchIDs = new Array()
+        const matchIDs = new Array()
         $('a.match-item').each((i, element) => {
           const matchID = $(element).attr('href')
           if (matchID) {
-            MatchIDs.push(matchID.split('/')[1])
+            matchIDs.push(matchID.split('/')[1])
           }
         })
 

--- a/src/scrapers/events/matches.ts
+++ b/src/scrapers/events/matches.ts
@@ -38,12 +38,14 @@ const fetchEventMatches = async (id: string): Promise<EventMatches> => {
           }
         })
 
-        // Optimize this to go through the cache at a later point
-        const MatchFetchPromises = new Array()
-        for (let i = 0; i < MatchIDs.length; i++) {
-          MatchFetchPromises.push(generateScore(MatchIDs[i]))
-        }
-        Event.matches = await Promise.all(MatchFetchPromises)
+        // request all match data from the API
+        let matches = await Promise.all(
+          matchIDs.map((matchId) => {
+            return fetch(`http://localhost:${PORT}/match/${matchId}`)
+          })
+        )
+        matches = await Promise.all(matches.map((res) => res.json()))
+        Event.matches = matches.map((match: any) => match.data)
 
         resolve(Event)
       })

--- a/src/scrapers/events/matches.ts
+++ b/src/scrapers/events/matches.ts
@@ -5,11 +5,11 @@ import { load } from 'cheerio'
 import { idGenerator } from '../util'
 // Schema
 import { z } from '@hono/zod-openapi'
-import { EventSchema } from '../../schemas/schemas'
+import { shortEventSchema } from '../../schemas/schemas'
 import { fetchOneMatch } from '../matches/one'
 import { generateScore } from '../matches/score'
 // Type
-type Event = z.infer<typeof EventSchema>
+type Event = z.infer<typeof shortEventSchema>
 
 const fetchEventMatches = async (id: string): Promise<Object> => {
   // Validate input

--- a/src/scrapers/events/one.ts
+++ b/src/scrapers/events/one.ts
@@ -4,15 +4,9 @@
 import { load } from 'cheerio'
 import { idGenerator } from '../util'
 // Schema
-import { z } from '@hono/zod-openapi'
-import { EventSchema } from '../../schemas/schemas'
-// Type
-type Event = z.infer<typeof EventSchema>
+import { Event, typeEnum } from '../../schemas/schemas'
 
-const fetchOneEvent = async (id: string): Promise<Object> => {
-  // Validate input
-  // make sure id is a string of numbers
-  if (!id.match(/^[0-9]+$/)) throw new Error('Invalid ID')
+const fetchOneEvent = async (id: string): Promise<Event> => {
   return new Promise(async (resolve, reject) => {
     // fetch the page
     fetch(`https://www.vlr.gg/event/${id}`)
@@ -27,22 +21,22 @@ const fetchOneEvent = async (id: string): Promise<Object> => {
         )
           reject('404')
         const Event = {} as Event
-        Event.type = 'event'
+        Event.type = typeEnum.Enum.Event
         Event.name = $('h1.wf-title').text().trim()
         Event.link = `https://www.vlr.gg/event/${id}`
         Event.id = id
-        Event.img =
+        Event.logo =
           'https:' + $('.wf-avatar.event-header-thumb img').attr('src')
         // Get all teams
         const Teams = new Array()
         $('.event-team').each((i, element) => {
-          const team = new Object()
+          const team = new Object() as Event['teams_item'][0]
           try {
             team.name = $(element).find('.event-team-name').text().trim()
-            team.logo = $(element)
-              .find('.event-team-players-mask > img')
-              .attr('src')
-            team.link = $(element).find('.event-team-name').attr('href')
+            team.logo =
+              $(element).find('.event-team-players-mask > img').attr('src') ||
+              ''
+            team.link = $(element).find('.event-team-name').attr('href') || ''
             team.id = idGenerator(team.link.split('/')[2])
             team.players = new Array()
             team.status = 'ok'
@@ -57,7 +51,7 @@ const fetchOneEvent = async (id: string): Promise<Object> => {
         const Players = new Array()
         const FailedLinks = new Array()
         $('.event-team-players-item').each((i, element) => {
-          const playerLink = $(element).attr('href')
+          const playerLink = $(element).attr('href') || ''
           let playerId
           try {
             playerId = idGenerator(playerLink.split('/')[2])
@@ -74,12 +68,13 @@ const fetchOneEvent = async (id: string): Promise<Object> => {
             .text()
             .trim()
           const playerTeamId = idGenerator(
-            $(element)
-              .parent()
-              .parent()
-              .find('.event-team-name')
-              .attr('href')
-              .split('/')[2]
+            (
+              $(element)
+                .parent()
+                .parent()
+                .find('.event-team-name')
+                .attr('href') || ''
+            ).split('/')[2]
           )
           for (let i = 0; i < Teams.length; i++) {
             if (Teams[i].name == playerTeamName) {

--- a/src/scrapers/matches/all.ts
+++ b/src/scrapers/matches/all.ts
@@ -6,11 +6,11 @@ import { idGenerator } from '../util'
 import { fetchOneMatch } from './one'
 // Schema
 import { z } from '@hono/zod-openapi'
-import { MatchSchema } from '../../schemas/schemas'
+import { AllMatchSchema } from '../../schemas/schemas'
 // Type
-type Match = z.infer<typeof MatchSchema>
+export type AllMatches = z.infer<typeof AllMatchSchema>
 
-const fetchAllMatches = async () => {
+const fetchAllMatches = async (): Promise<AllMatches> => {
   return new Promise(async (resolve, reject) => {
     // fetch the page
     fetch(`https://www.vlr.gg/matches`)
@@ -18,7 +18,7 @@ const fetchAllMatches = async () => {
       .then((data) => {
         // parse the page
         let $ = load(data)
-        let Matches = new Array()
+        let Matches: AllMatches = new Array()
         const Labels = $(
           '#wrapper > div.col-container > div:nth-child(1) > .wf-label.mod-large'
         )
@@ -43,7 +43,7 @@ const fetchAllMatches = async () => {
               const link = $(match).attr('href')
               if (!link) return
               const id = idGenerator(link.split('/')[1])
-              // Should run this through  the cache instead,
+              // Should run this through the cache instead,
               // Fix later
               MatchPulls.push(
                 fetchOneMatch(id).then((data) => {

--- a/src/scrapers/matches/one.ts
+++ b/src/scrapers/matches/one.ts
@@ -23,6 +23,7 @@ const fetchOneMatch = async (id: string): Promise<Object> => {
         let $ = load(data)
         const Match = new Object() as Match
 
+        Match.type = typeEnum.Enum.Match
         Match.id = id
         Match.date = $('.match-header-date .moment-tz-convert:nth-child(1)')
           .text()

--- a/src/scrapers/matches/one.ts
+++ b/src/scrapers/matches/one.ts
@@ -11,7 +11,7 @@ import {
   MatchSchema,
   PlayerMatchStatsElement,
   PlayerStats,
-  TeamExtended,
+  GameTeamExtended,
   statusEnum,
   typeEnum,
 } from '../../schemas/schemas'
@@ -116,8 +116,8 @@ const fetchOneMatch = async (id: string): Promise<Match> => {
           // TODO: make map a enum
           Match.games[i].map = map
           Match.games[i].teams = new Array()
-          Match.games[i].teams[0] = new Object() as TeamExtended
-          Match.games[i].teams[1] = new Object() as TeamExtended
+          Match.games[i].teams[0] = new Object() as GameTeamExtended
+          Match.games[i].teams[1] = new Object() as GameTeamExtended
           Match.games[i].teams[0].name = Match.teams[0].name
           Match.games[i].teams[1].name = Match.teams[1].name
           //TODO: scrape Scores

--- a/src/scrapers/matches/one.ts
+++ b/src/scrapers/matches/one.ts
@@ -9,9 +9,8 @@ import {
   ExtStats,
   Game,
   MatchSchema,
-  PlayerBaseElement,
   PlayerMatchStatsElement,
-  Stats,
+  PlayerStats,
   TeamExtended,
   statusEnum,
   typeEnum,
@@ -156,7 +155,7 @@ const fetchOneMatch = async (id: string): Promise<Match> => {
                 .attr('href')}`
               const playerStats = $(element).find('.mod-stat')
               player.statsAdvanced = new Object() as ExtStats
-              player.stats = new Object() as Stats
+              player.stats = new Object() as PlayerStats
               playerStats.each((i, element) => {
                 const ct = $(element).find('.mod-ct').text().trim()
                 const t = $(element).find('.mod-t').text().trim()

--- a/src/scrapers/matches/one.ts
+++ b/src/scrapers/matches/one.ts
@@ -20,10 +20,6 @@ import {
 export type Match = z.infer<typeof MatchSchema>
 
 const fetchOneMatch = async (id: string): Promise<Match> => {
-  // Validate input
-  // make sure id is a string of numbers
-  if (!id) return {}
-  else if (!id.match(/^[0-9]+$/)) throw new Error('Invalid ID')
   return new Promise(async (resolve, reject) => {
     // fetch the page
     fetch(`https://www.vlr.gg/${id}`)

--- a/src/scrapers/matches/one.ts
+++ b/src/scrapers/matches/one.ts
@@ -9,9 +9,9 @@ import {
   ExtStats,
   Game,
   MatchSchema,
-  Player,
+  PlayerBaseElement,
+  PlayerMatchStatsElement,
   Stats,
-  Team,
   TeamExtended,
   statusEnum,
   typeEnum,
@@ -142,7 +142,7 @@ const fetchOneMatch = async (id: string): Promise<Match> => {
                   .trim() == ''
               )
                 return
-              const player = new Object() as Player
+              const player = new Object() as PlayerMatchStatsElement
               player.name = $(element)
                 .find('.mod-player a div:nth-child(1)')
                 .text()

--- a/src/scrapers/matches/score.ts
+++ b/src/scrapers/matches/score.ts
@@ -1,40 +1,34 @@
-import { fetchOneMatch } from "./one"
 // Schema
 import { z } from '@hono/zod-openapi'
-import { MatchSchema } from '../../schemas/schemas'
+import { MatchSchema, Score } from '../../schemas/schemas'
+import { PORT } from '../..'
 // Types
 type Match = z.infer<typeof MatchSchema>
 
-type ScoresObject = {
-    [index: string]:Number
-}
-type PlayerScoreObject = {
-    name: String,
-    score: Number
-}
-
-const generateScore = async (id: string) => {
-    const match : Match = await fetchOneMatch(id);
-    const scores_object: ScoresObject = {};
-    const scores_array: PlayerScoreObject[] = [];
-    // Itterate through the players, generate score based on formula
-    match.players.forEach((player)=>{
-        let score = 0;
-        score += Number(player.stats.acs);
-        score += Number(player.stats.k) * 4;
-        score -= Number(player.stats.d) * 3;
-        score += Number(player.stats.a) * 2;
-        score += Number(player.stats.fk) * 5;
-        score -= Number(player.stats.fd) * 4;
-        scores_object[player.name] = score;
-        scores_array.push({"name": player.name, "score": score})
-    })
-    return {
-        id,
-        scores_array,
-        scores_object,
-        match
-    };
+const generateScore = async (id: string): Promise<Score> => {
+  const match: Match = await (
+    await fetch(`localhost:${PORT}/match/${id}`).then((res) => res.json())
+  ).data
+  const scores_object: Score['scores_object'] = {}
+  const scores_array: Score['scores_array'] = []
+  // Itterate through the players, generate score based on formula
+  match.players.forEach((player) => {
+    let score = 0
+    score += Number(player.stats.acs)
+    score += Number(player.stats.k) * 4
+    score -= Number(player.stats.d) * 3
+    score += Number(player.stats.a) * 2
+    score += Number(player.stats.fk) * 5
+    score -= Number(player.stats.fd) * 4
+    scores_object[player.name] = score
+    scores_array.push({ name: player.name, score: score })
+  })
+  return {
+    id,
+    scores_array,
+    scores_object,
+    match,
+  }
 }
 
-export {generateScore}
+export { generateScore }

--- a/src/scrapers/player/one.ts
+++ b/src/scrapers/player/one.ts
@@ -3,11 +3,7 @@
 // External Libs
 import { load } from 'cheerio'
 import { idGenerator, AgentArray } from '../util'
-// Schema
-import { z } from '@hono/zod-openapi'
-import { PlayerSchema } from '../../schemas/schemas'
-// Type
-type Player = z.infer<typeof PlayerSchema>
+import { AgentStats, PlayerAgentStats, Player } from '../../schemas/schemas'
 
 const fetchOnePlayer = async (id: string) => {
   // Validate input
@@ -16,14 +12,14 @@ const fetchOnePlayer = async (id: string) => {
   if (!id.match(/^[0-9,]+/gm)) throw new Error('Invalid ID')
   if (!id.match(/^[0-9,]+/)) throw new Error(`Invalid ID: ${id}`)
   let idArray = id.split(',')
-  let PromiseArray = new Array()
+  let PromiseArray: Promise<Player>[] = new Array()
   for (let i = 0; i < idArray.length; i++) {
     PromiseArray.push(fetchPlayer(idArray[i]))
   }
   return Promise.all(PromiseArray)
 }
 
-const fetchPlayer = async (id: string) => {
+export const fetchPlayer = async (id: string): Promise<Player> => {
   return new Promise(async (resolve, reject) => {
     // fetch the page
     fetch(`https://www.vlr.gg/player/${id}`)
@@ -39,21 +35,21 @@ const fetchPlayer = async (id: string) => {
         )
           reject('404')
 
-        let Player = new Object()
+        let Player = new Object() as Player
         Player.ign = $('h1.wf-title').text().trim()
         Player.name = Player.ign
         Player.realName = $('h2.player-real-name').text().trim()
         Player.id = idGenerator(id)
         Player.link = `https://www.vlr.gg/player/${id}`
-        Player.photo = cleanPhoto($('.player-header img').attr('src'))
+        Player.photo = cleanPhoto($('.player-header img').attr('src') || '')
         Player.country = cleanCountry(
           $('.player-header .ge-text-light').text().trim()
         )
         Player.team =
           $('div.player-summary-container-1 > div:nth-child(6) > a')
             .attr('href')
-            ?.split('/')[2] ?? null
-        if (Player.team !== null) Player.team = idGenerator(Player.team)
+            ?.split('/')[2] ?? undefined
+        if (Player.team) Player.team = idGenerator(Player.team)
         Player.role = $('.profile-role').text().trim()
         Player.earnings = $(
           '.player-summary-container-2 .wf-card:nth-child(4) span'
@@ -61,13 +57,14 @@ const fetchPlayer = async (id: string) => {
           .text()
           .trim()
           ?.split('\n')[0]
-        Player.stats = new Object()
+
+        Player.stats = new Object() as PlayerAgentStats
         // Generate Player Stats
         const statsTable = $('table.wf-table').first()
-        const statRows = $(statsTable).find('tr')
+        const statRows = $(statsTable).find('tbody tr')
         const statLabels = $(statsTable).find('th')
         // Create array of stat labels
-        const statLabelsArray = []
+        const statLabelsArray: string[] = []
         $(statLabels).each((i, element) => {
           if (i == 0) statLabelsArray.push('Agent')
           else statLabelsArray.push($(element).text().trim())
@@ -79,17 +76,15 @@ const fetchPlayer = async (id: string) => {
         // itterate through each row in the table (default t60)
         $(statRows).each((i, element) => {
           // Create a new object for each row
-          Player.stats.data[i] = new Object()
+          Player.stats.data[i] = new Object() as AgentStats
           // itterate through each td in the row and add it to the playerStats object
           $(element)
             .find('td')
             .each((j, element) => {
-              const statLabel = statLabelsArray[j]
+              const statLabel = statLabelsArray[j] as keyof AgentStats
               let statValue
               if (statLabel == 'Agent')
-                statValue = $(element)
-                  .find('img')
-                  .attr('src')
+                statValue = ($(element).find('img').attr('src') || '')
                   .split('/')[5]
                   .split('.')[0]
               else if (statLabel == 'Use')
@@ -98,31 +93,32 @@ const fetchPlayer = async (id: string) => {
               Player.stats.data[i][statLabel] = statValue
             })
         })
-        // Remove the first stat row (it's the header)
-        Player.stats.data.shift()
         // Add the agent array for stats
-        Player.agentStats = new Object()
-        Player.agentStats.labels = AgentArray
+        Player.agentStats = new Object() as Player['agentStats']
         for (let i = 0; i < AgentArray.length; i++) {
-          Player.agentStats[AgentArray[i]] = new Object()
+          const agentName = AgentArray[i] as keyof Player['agentStats']
+
+          Player.agentStats[agentName] = new Object() as AgentStats
           // Add the agent stats with no data
           for (let j = 0; j < statLabelsArray.length; j++) {
-            if (statLabelsArray[j] == 'Agent')
-              Player.agentStats[AgentArray[i]][statLabelsArray[j]] =
-                AgentArray[i]
-            Player.agentStats[AgentArray[i]][statLabelsArray[j]] = 0
+            const statsLabel = statLabelsArray[j] as keyof AgentStats
+
+            if (statsLabel == 'Agent')
+              Player.agentStats[agentName]['Agent'] = agentName
+            Player.agentStats[agentName][statsLabel] = '0'
           }
         }
         // Add the agent stats with data
-        for (let i = 0; i < Player.stats.data.length; i++) {
-          const agent = Player.stats.data[i].Agent
+        Player.stats.data.forEach((element, i) => {
+          const agent = element.Agent as keyof Player['agentStats']
           for (let j = 0; j < statLabelsArray.length; j++) {
-            const statLabel = statLabelsArray[j]
+            const statLabel = statLabelsArray[j] as keyof AgentStats
             if (statLabel == 'Agent') continue
+
             Player.agentStats[agent][statLabel] =
               Player.stats.data[i][statLabel]
           }
-        }
+        })
 
         resolve(Player)
       })

--- a/src/scrapers/player/one.ts
+++ b/src/scrapers/player/one.ts
@@ -20,6 +20,10 @@ const fetchOnePlayer = async (id: string) => {
 }
 
 export const fetchPlayer = async (id: string): Promise<Player> => {
+  // check if id is intern
+  if (id[0] === '0') {
+    id = id.replace(/^[0]+/gm, '')
+  }
   return new Promise(async (resolve, reject) => {
     // fetch the page
     fetch(`https://www.vlr.gg/player/${id}`)

--- a/src/scrapers/team/one.ts
+++ b/src/scrapers/team/one.ts
@@ -4,11 +4,9 @@
 import { load } from 'cheerio'
 import { idGenerator } from '../util'
 import { PORT } from '../..'
+import { Player, Team } from '../../schemas/schemas'
 
-const fetchOneTeam = async (id: string): Promise<Object> => {
-  // Validate input
-  // make sure id is a string of numbers
-  if (!id.match(/^[0-9,]+$/)) throw new Error('Invalid ID')
+const fetchOneTeam = async (id: string): Promise<Team> => {
   return new Promise(async (resolve, reject) => {
     // fetch the page
     fetch(`https://www.vlr.gg/team/${id}`)
@@ -23,7 +21,7 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
             .includes('Page not found')
         )
           reject('404')
-        let Team = new Object()
+        let Team = new Object() as Team
         // Team Name,, Logo, Region, Socials, Roster, Staff, Earnings
         Team.name = $('h1.wf-title').text().trim()
         Team.tag = $('h2.wf-title.team-header-tag').text().trim()
@@ -39,7 +37,7 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
         if (Team.logo.includes('/img/vlr/tmp/vlr.png'))
           Team.logo = 'https://www.vlr.gg/img/vlr/tmp/vlr.png'
         // Get Socials
-        $('.team-header-links a').each(async (i, element) => {
+        $('.team-header-links a').each((i, element) => {
           let socialLink = $(element).attr('href')
           if (socialLink === '' || socialLink === undefined) return
           // add https if not there
@@ -50,7 +48,7 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
             socialURL = new URL(socialLink)
           } catch {
             console.error(
-              'Error setting socialURL: ' + socialLink + ' | Page: ' + url,
+              'Error setting socialURL: ' + socialLink + ' | Page: ',
               false
             )
             console.info('FUCKING SOCIAL LINKS CAN SUCK MY ASS')
@@ -61,7 +59,7 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
           Team.socials.push({ name: socialName, link: socialLink })
         })
         // Generaate Players and Staff
-        Team.players_item = new Array()
+        const players_item: any[] = new Array()
         Team.staff_item = new Array()
         $('.team-roster-item').each((i, element) => {
           const playerLink = $(element).find('.team-roster-item a').attr('href')
@@ -82,7 +80,7 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
             .trim()
           if (playerRole === '' || playerRole === undefined) {
             playerRole = 'player'
-            Team.players_item.push({
+            players_item.push({
               ign: playerIgn,
               link: `https://www.vlr.gg${playerLink}`,
               id: idGenerator(playerId),
@@ -98,24 +96,19 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
           }
         })
 
-        // Generate team.players array of ids
-        Team.players = new Array()
-        Team.players_item.forEach((player) => {
-          Team.players.push(idGenerator(player.id))
-        })
         // SICK way of keeping players cached ;)
-        const PlayerPromises = [
-          ...Team.players_item.map((player) => {
+        const playerPromises = [
+          ...players_item.map((player) => {
             return fetch(`http://localhost:${PORT}/player/${player.id}`)
           }),
           ...Team.staff_item.map((player) => {
             return fetch(`http://localhost:${PORT}/player/${player.id}`)
           }),
         ]
-        let Players = await Promise.all(PlayerPromises)
-        Players = await Promise.all(Players.map((res) => res.json()))
-        Team.players = Players.map((player) => player.data)
-        delete Team.players_item
+        let players = await Promise.all(playerPromises)
+        players = await Promise.all(players.map((res) => res.json()))
+        Team.players = players.map((player: any) => player.data)
+
         // Generate team.staff array of ids
         Team.staff = new Array()
         Team.staff_item.forEach((player) => {

--- a/src/scrapers/team/one.ts
+++ b/src/scrapers/team/one.ts
@@ -32,6 +32,7 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
         Team.country = $('.team-header-country').text().trim()
         Team.link = `https://vlr.gg/team/${id}`
         Team.socials = new Array()
+        // TODO: Does not work
         Team.earnings = $('.team-earnings-value').text().trim()
 
         // Fix Logo

--- a/src/scrapers/team/one.ts
+++ b/src/scrapers/team/one.ts
@@ -3,11 +3,7 @@
 // External Libs
 import { load } from 'cheerio'
 import { idGenerator } from '../util'
-// Schema
-import { z } from '@hono/zod-openapi'
-import { TeamSchema } from '../../schemas/schemas'
-// Type
-type Team = z.infer<typeof TeamSchema>
+import { PORT } from '../..'
 
 const fetchOneTeam = async (id: string): Promise<Object> => {
   // Validate input
@@ -109,10 +105,10 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
         // SICK way of keeping players cached ;)
         const PlayerPromises = [
           ...Team.players_item.map((player) => {
-            return fetch('http://localhost:3000/player/' + player.id)
+            return fetch(`http://localhost:${PORT}/player/${player.id}`)
           }),
           ...Team.staff_item.map((player) => {
-            return fetch('http://localhost:3000/player/' + player.id)
+            return fetch(`http://localhost:${PORT}/player/${player.id}`)
           }),
         ]
         let Players = await Promise.all(PlayerPromises)

--- a/src/scrapers/team/one.ts
+++ b/src/scrapers/team/one.ts
@@ -113,7 +113,7 @@ const fetchOneTeam = async (id: string): Promise<Object> => {
         ]
         let Players = await Promise.all(PlayerPromises)
         Players = await Promise.all(Players.map((res) => res.json()))
-        Team.players = Players.map((player) => player.data[0]);
+        Team.players = Players.map((player) => player.data)
         delete Team.players_item
         // Generate team.staff array of ids
         Team.staff = new Array()

--- a/src/scrapers/util.ts
+++ b/src/scrapers/util.ts
@@ -37,7 +37,9 @@ let AgentArray = [
 fetch('https://valorant-api.com/v1/agents')
   .then((res) => res.json())
   .then((data) => {
-    AgentArray = data.data.map((agent: any) => agent.displayName)
+    AgentArray = data.data
+      .map((agent: any) => agent.displayName.toLowerCase().replace('/', ''))
+      .sort()
     console.log('Agents Updated')
   })
 


### PR DESCRIPTION
Adding schemas for all Endpoints and change implementation to make use of them.

I tried to keep the changes to API responses to a minimum, but still there were some changes I made to make responses more similar to each other, IMO.
## Changes to API Responses
- events/:id
  - img ⇾ logo | because it's called logo in almost all other responses
- events/:id/matches endpoint now requests the API instead of the generate scores function
- match/:id
  - add "type" to response
  - eventid ⇾ eventId
  - eventname ⇾ eventName
  - mapScore ⇾ score
  - advancedScore object now has "t" instead of "c" I think this was a typo originally

There were some errors occurring and some other things that I fixed/changed/added that wear not related to responses
## Changes not related to Schemas
- add env var to disable cache. Added this because I needed it for debugging
- skipping caching for request that return with status 404
- fix the longer caching for the match route
- move routes initialization to function to make use of types
- move param validation to the route to have easier access to it
- make enums for some recurring string fields
- score function now requests API instead of calling the match function
- now normalizes and sorts agents received from Riot API

I hope I could make some arguments for the changes. If there are questions, I'm happy to answer them :)

- closes #3 